### PR TITLE
[#1305938] resc-frontend UI improvements

### DIFF
--- a/components/resc-frontend/package.json
+++ b/components/resc-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resc-frontend",
-  "version": "0.7.32",
+  "version": "0.7.33",
   "author": "ABN AMRO Bank",
   "description": "Repository Scanner Frontend",
   "repository": {

--- a/components/resc-frontend/src/components/Metrics/RuleMetrics.vue
+++ b/components/resc-frontend/src/components/Metrics/RuleMetrics.vue
@@ -23,6 +23,7 @@
         :fields="fields"
         primary-key="rule_name"
         responsive
+        small
         head-variant="light"
         @row-clicked="goToRuleAnalysisPage"
       >

--- a/components/resc-frontend/src/components/RepositoryBranches/RepositoryBranchesPanel.vue
+++ b/components/resc-frontend/src/components/RepositoryBranches/RepositoryBranchesPanel.vue
@@ -19,6 +19,7 @@
         primary-key="id_"
         v-model="currentItems"
         responsive
+        small
         head-variant="light"
         @row-clicked="goToFindings"
       >

--- a/components/resc-frontend/src/components/ScanFindings/FindingTab.vue
+++ b/components/resc-frontend/src/components/ScanFindings/FindingTab.vue
@@ -5,6 +5,12 @@
         <!-- Finding info -->
         <div class="col-md-6">
           <b-card-text
+            ><span class="font-weight-bold">Commit ID: </span
+            ><a class="custom-link" v-bind:href="finding.commit_url" target="_blank">{{
+              finding.commit_id
+            }}</a></b-card-text
+          >
+          <b-card-text
             ><span class="font-weight-bold">File Path: </span>{{ finding.file_path }}</b-card-text
           >
           <b-card-text
@@ -18,18 +24,12 @@
             ><span class="font-weight-bold">Email: </span>{{ finding.email }}</b-card-text
           >
           <b-card-text
-            ><span class="font-weight-bold">Commit ID: </span
-            ><a class="custom-link" v-bind:href="finding.commit_url" target="_blank">{{
-              finding.commit_id
-            }}</a></b-card-text
+            ><span class="font-weight-bold">Commit Time: </span
+            >{{ finding.commit_timestamp }}</b-card-text
           >
           <b-card-text
             ><span class="font-weight-bold">Commit Message: </span
-            >{{ finding.commit_message }}</b-card-text
-          >
-          <b-card-text
-            ><span class="font-weight-bold">Commit Time: </span
-            >{{ finding.commit_timestamp }}</b-card-text
+            >{{ finding.commit_message | truncate(50, '...') }}</b-card-text
           >
           <b-card-text
             ><span class="font-weight-bold">Rulepack: </span>{{ finding.rule_pack }}</b-card-text
@@ -43,11 +43,12 @@
               <b-form-group
                 label="Status"
                 label-for="status-select"
-                label-class="mr-sm-2 font-weight-bold"
+                label-class="mr-sm-2 font-weight-bold small"
               >
                 <b-form-select
                   id="status-select"
                   class="mb-2 mr-sm-2 mb-sm-0"
+                  size="sm"
                   v-model="form.status"
                   @change="checkFormValidity"
                 >
@@ -59,7 +60,7 @@
               <b-form-group
                 label="Comment"
                 label-for="comment-textarea"
-                label-class="mr-sm-2 font-weight-bold"
+                label-class="mr-sm-2 font-weight-bold small"
                 invalid-feedback="Maximum 255 characters are allowed"
                 :state="commentState"
               >
@@ -67,6 +68,7 @@
                   id="comment-textarea"
                   v-model="form.comment"
                   placeholder="Enter Comment"
+                  size="sm"
                   rows="3"
                   trim
                   :state="commentState"
@@ -110,6 +112,15 @@ export default {
     repository: {
       type: Object,
       required: true,
+    },
+  },
+  filters: {
+    truncate: function (text, length, suffix) {
+      if (text.length > length) {
+        return text.substring(0, length) + suffix;
+      } else {
+        return text;
+      }
     },
   },
   methods: {

--- a/components/resc-frontend/src/styles/main.css
+++ b/components/resc-frontend/src/styles/main.css
@@ -102,9 +102,27 @@
   cursor: default !important;
 }
 
+.b-table-details {
+  border-left: 2px solid #b3daeb !important;
+  border-right: 2px solid #b3daeb !important;
+  border-bottom: 2px solid #b3daeb !important;
+}
+
+.b-table-details td{
+  padding: 0;
+}
+
+.b-table-has-details{
+  border-top: 2px solid #b3daeb !important;
+  border-left: 2px solid #b3daeb !important;
+  border-right: 2px solid #b3daeb !important;
+  background-color: #e4f9f5;
+}
+
 /* Tabs */
 .card-header {
   background-color: #e4f9f5;
+  display: none;
 }
 .nav-pills .tab-pills .nav-link:not(.active) {
   background-color: transparent !important;
@@ -114,6 +132,10 @@
 .nav-pills .tab-pills .nav-link {
   background-color: #38aba1 !important;
   font-weight: bold;
+}
+.card-text {
+  margin: 10px;
+  font-size: small;
 }
 
 /* Pagination */

--- a/components/resc-frontend/src/views/Repositories.vue
+++ b/components/resc-frontend/src/views/Repositories.vue
@@ -34,6 +34,7 @@
         primary-key="id_"
         v-model="currentItems"
         responsive
+        small
         head-variant="light"
         @row-clicked="toggleRepositoryDetails"
       >

--- a/components/resc-frontend/src/views/RuleAnalysis.vue
+++ b/components/resc-frontend/src/views/RuleAnalysis.vue
@@ -52,6 +52,7 @@
         primary-key="id_"
         v-model="currentItems"
         responsive
+        small
         head-variant="light"
         @row-clicked="toggleFindingDetails"
       >

--- a/components/resc-frontend/src/views/RulePacks.vue
+++ b/components/resc-frontend/src/views/RulePacks.vue
@@ -41,6 +41,7 @@
         primary-key="version"
         v-model="currentItems"
         responsive
+        small
         head-variant="light"
       >
         <!-- Version Column -->

--- a/components/resc-frontend/src/views/ScanFindings.vue
+++ b/components/resc-frontend/src/views/ScanFindings.vue
@@ -61,6 +61,7 @@
         primary-key="id_"
         v-model="currentItems"
         responsive
+        small
         head-variant="light"
         @row-clicked="toggleFindingDetails"
       >


### PR DESCRIPTION
Less padding for findings details panel and all tables
changed order of info in finding details panel
highlighting selected row opened with details in the table

