### PR TITLE
[#2021472] Updated rabbitmq image to fix CVE-2023-0286 reported in openssl, skipping helm chart publishing if version already published

### DIFF
--- a/.github/workflows/k8-infra-ci.yaml
+++ b/.github/workflows/k8-infra-ci.yaml
@@ -92,3 +92,4 @@ jobs:
         charts_dir: deployment
       env:
         CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        CR_SKIP_EXISTING: true

--- a/deployment/kubernetes/README.md
+++ b/deployment/kubernetes/README.md
@@ -187,15 +187,15 @@ Examples:
 ```bash
 docker pull mcr.microsoft.com/azure-sql-edge:1.0.5
 
-docker pull rabbitmq:3.11.2-management-alpine
+docker pull rabbitmq:3.11.9-management-alpine
 
-docker pull rescabnamro/resc-backend:1.0.1
+docker pull rescabnamro/resc-backend:latest
 
-docker pull rescabnamro/resc-frontend:1.0.1
+docker pull rescabnamro/resc-frontend:latest
 
-docker pull rescabnamro/resc-vcs-scraper:1.0.1
+docker pull rescabnamro/resc-vcs-scraper:latest
 
-docker pull rescabnamro/resc-vcs-scanner:1.0.1
+docker pull rescabnamro/resc-vcs-scanner:latest
 ```
 
 ### Trigger scanning

--- a/deployment/kubernetes/charts/resc-rabbitmq/values.yaml
+++ b/deployment/kubernetes/charts/resc-rabbitmq/values.yaml
@@ -2,7 +2,7 @@ rabbitMQ:
   image:
     repository:
     name: rabbitmq
-    tag: 3.11.6-management-alpine
+    tag: 3.11.9-management-alpine
     pullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
Updated rabbitmq image to fix CVE-2023-0286 reported in openssl
skipping helm chart publishing if version already published
