### PR TITLE
2202540 bugfix rule dropdown when latest rulepack version selected on Rule Analysis screen

### DIFF
--- a/components/resc-frontend/src/components/Filters/RuleAnalysisFilter.vue
+++ b/components/resc-frontend/src/components/Filters/RuleAnalysisFilter.vue
@@ -80,6 +80,7 @@
               :selectedRulePackVersionsList="selectedRulePackVersionsList"
               :rulePackVersions="rulePackVersions"
               @on-rule-pack-version-change="onRulePackVersionChange"
+              @on-latest-rule-pack-version-selection="onLatestRulePackVersionSelection"
             />
           </div>
         </div>
@@ -199,6 +200,18 @@ export default {
       this.handleFilterChange();
     },
 
+    onLatestRulePackVersionSelection(rulePackVersions) {
+      const rulePackVersionValues = [];
+      for (const rulePackVersion of rulePackVersions) {
+        const version = rulePackVersion.label.split(' ');
+        rulePackVersionValues.push(version.length > 0 ? version[0] : rulePackVersion.label);
+      }
+      this.selectedRulePackVersions = rulePackVersionValues;
+
+      // Fetch detected rules for latest rule pack selection
+      this.fetchAllDetectedRules();
+    },
+
     handleFilterChange() {
       // Refresh table data in Rule Analysis page
       const filterObj = {};
@@ -266,7 +279,6 @@ export default {
     },
   },
   created() {
-    this.fetchAllDetectedRules();
     this.applyRuleFilterInRuleAnalysisPage();
   },
   components: {

--- a/components/resc-frontend/src/components/Filters/RulePackFilter.vue
+++ b/components/resc-frontend/src/components/Filters/RulePackFilter.vue
@@ -71,7 +71,7 @@ export default {
     ) {
       this.initialized = true;
       this.selectedVersions = this.selectedRulePackVersionsList;
-      this.$emit('on-rule-pack-version-init', this.selectedVersions);
+      this.$emit('on-latest-rule-pack-version-selection', this.selectedVersions);
     }
   },
 };

--- a/components/resc-frontend/src/components/Filters/RulePackFilter.vue
+++ b/components/resc-frontend/src/components/Filters/RulePackFilter.vue
@@ -71,6 +71,7 @@ export default {
     ) {
       this.initialized = true;
       this.selectedVersions = this.selectedRulePackVersionsList;
+      this.$emit('on-rule-pack-version-init', this.selectedVersions);
     }
   },
 };


### PR DESCRIPTION
Investigated the bug and found currently the rules are not waiting for the latest version of the rule pack to be selected. Therefore the rule pack version value is getting passed as null while fetching the rules during the initial load.

To fix this issue we need to call the rules endpoint only after the latest version of the rule pack gets selected in the rule pack dropdown.