### PR TITLE
[#2466269] Fix bug resc-rules-init job not being removed as part of helm uninstall

### DIFF
--- a/deployment/kubernetes/charts/resc-rules-init/templates/rules_job.yaml
+++ b/deployment/kubernetes/charts/resc-rules-init/templates/rules_job.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Values.global.namespace }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   ttlSecondsAfterFinished: 600
   template:


### PR DESCRIPTION
Fix bug resc-rules-init job not being removed as part of helm uninstall
