### PR TITLE
Fix typo: `requires_python` -> `python_requires`.

### DIFF
--- a/components/resc-backend/setup.cfg
+++ b/components/resc-backend/setup.cfg
@@ -10,7 +10,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 
 [options]
-requires_python = >=3.9
+python_requires = >=3.9
 include_package_data = False
 zip_safe = False
 package_dir = = src

--- a/components/resc-vcs-scanner/setup.cfg
+++ b/components/resc-vcs-scanner/setup.cfg
@@ -10,7 +10,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 
 [options]
-requires_python = >=3.9
+python_requires = >=3.9
 include_package_data = False
 zip_safe = False
 package_dir = = src

--- a/components/resc-vcs-scraper/setup.cfg
+++ b/components/resc-vcs-scraper/setup.cfg
@@ -10,7 +10,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 
 [options]
-requires_python = >=3.9
+python_requires = >=3.9
 include_package_data = False
 zip_safe = False
 package_dir = = src

--- a/deployment/resc-helm-wizard/setup.cfg
+++ b/deployment/resc-helm-wizard/setup.cfg
@@ -10,7 +10,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 
 [options]
-requires_python = >=3.9
+python_requires = >=3.9
 include_package_data = True
 zip_safe = False
 package_dir = = src


### PR DESCRIPTION
See [python_requires](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#python-requires) documentation.

Currently the package is installed irrespective of Python version.
With this change we now have the following when attempting an installation in an environment with a Python version < 3.9:
```python
(venv38) resc-backend % pwd
/Users/markbyrne/programming/repository-scanner/components/resc-backend
(venv38) resc-backend % pip install -e .

ERROR: Package 'resc-backend' requires a different Python: 3.8.0 not in '>=3.9'
```