### PR TITLE
CI - run tests on all supported Python versions (scoped to helm-wizard only)

### DIFF
--- a/.github/workflows/helm-wizard-ci.yaml
+++ b/.github/workflows/helm-wizard-ci.yaml
@@ -22,46 +22,73 @@ on:
   workflow_dispatch:
 
 env:
-  RESC_HELM_WIZARD_DIR: deployment/resc-helm-wizard
+  CACHE_KEY_PREFIX: tox-dir
 
 jobs:
   python-basic-validation:
     name: Python Basic Validation
     runs-on: ubuntu-latest
-
+    defaults:
+      run:
+        working-directory: deployment/resc-helm-wizard
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        include:
+          - name: Run tests with Python 3.9
+            python-version: "3.9"
+            toxenv: py
+          - name: Run tests with Python 3.10
+            python-version: "3.10"
+            toxenv: py
+          - name: Run tests with Python 3.11
+            python-version: "3.11"
+            toxenv: py
+          - name: Run flake8 with Python 3.11
+            python-version: "3.11"
+            toxenv: flake8
+          - name: Run isort with Python 3.11
+            python-version: "3.11"
+            toxenv: isort
+          - name: Run pylint with Python 3.11
+            python-version: "3.11"
+            toxenv: pylint
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
+      id: python
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        check-latest: true
 
-    - name: Install test dependencies
-      run: |
-        cd ${{ env.RESC_HELM_WIZARD_DIR }}
-        pip install -r test-requirements.txt
-        tox
+    - name: Create tox cache key
+      id: tox-cache-key
+      run: >-
+        echo "key=${{ env.CACHE_KEY_PREFIX }}-${{ hashFiles('setup.cfg', 'test-requirements.txt', 'tox.ini') }}" >> $GITHUB_OUTPUT
 
-    - name: Test with pytest
-      run: |
-        cd ${{ env.RESC_HELM_WIZARD_DIR }}
-        tox -e pytest
+    - name: Cache .tox directory
+      id: cache-tox-dir
+      uses: actions/cache@v3.3.1
+      with:
+        path: .tox
+        key: >-
+          ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{ steps.tox-cache-key.outputs.key }}
 
-    - name: Import sorting with isort
+    - name: Install tox
+      run: pip install -U pip setuptools tox
+
+    - name: Create ${{ matrix.python-version }} tox env. and install dependencies
+      if: steps.cache-tox-dir.outputs.cache-hit != 'true'
       run: |
-        cd ${{ env.RESC_HELM_WIZARD_DIR }}
-        tox -e sort
-    
-    - name: Lint with flake8
+        tox run -e ${{ matrix.toxenv }} --notest
+
+    - name: Test
       run: |
-        cd ${{ env.RESC_HELM_WIZARD_DIR }}
-        tox -e lint
+        tox run -e ${{ matrix.toxenv }}
 
     - name: Get Branch Name
       id: extract_branch
@@ -100,7 +127,6 @@ jobs:
 
       - name: Building python package
         run: |
-          cd ${{ env.RESC_HELM_WIZARD_DIR }}
           python -m pip install --upgrade pip
           pip install build wheel
           python setup.py sdist bdist_wheel
@@ -110,13 +136,12 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.__PYPI_TOKEN__ }}
-          packages_dir: ${{ env.RESC_HELM_WIZARD_DIR }}/dist
+          packages_dir: dist
           skip_existing: true
 
       - id: getversion
         name: Get package version
         run: | 
-          cd ${{ env.RESC_HELM_WIZARD_DIR }}
           wizard_version=$(python ./setup.py --version)
           echo "wizard_version=$wizard_version" >> $GITHUB_OUTPUT
       

--- a/.github/workflows/helm-wizard-ci.yaml
+++ b/.github/workflows/helm-wizard-ci.yaml
@@ -53,7 +53,6 @@ jobs:
           - name: Run pylint with Python 3.11
             python-version: "3.11"
             toxenv: pylint
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/helm-wizard-ci.yaml
+++ b/.github/workflows/helm-wizard-ci.yaml
@@ -65,18 +65,14 @@ jobs:
         python-version: ${{ matrix.python-version }}
         check-latest: true
 
-    - name: Create tox cache key
-      id: tox-cache-key
-      run: >-
-        echo "key=${{ env.CACHE_KEY_PREFIX }}-${{ hashFiles('setup.cfg', 'test-requirements.txt', 'tox.ini') }}" >> $GITHUB_OUTPUT
-
     - name: Cache .tox directory
       id: cache-tox-dir
       uses: actions/cache@v3.3.1
       with:
         path: .tox
         key: >-
-          ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{ steps.tox-cache-key.outputs.key }}
+          ${{ runner.os }}-${{ steps.python.outputs.python-version
+          }}-${{ env.CACHE_KEY_PREFIX }}-${{ hashFiles('setup.cfg', 'test-requirements.txt', 'tox.ini') }}
 
     - name: Install tox
       run: pip install -U pip setuptools tox
@@ -110,6 +106,9 @@ jobs:
     name: Python Build and Publish
     needs: python-basic-validation
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: deployment/resc-helm-wizard
 
     strategy:
       matrix:

--- a/.github/workflows/helm-wizard-ci.yaml
+++ b/.github/workflows/helm-wizard-ci.yaml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   python-basic-validation:
-    name: Python Basic Validation
+    name: Tests
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -69,10 +69,11 @@ jobs:
       id: cache-tox-dir
       uses: actions/cache@v3.3.1
       with:
-        path: .tox
+        path: deployment/resc-helm-wizard/.tox
         key: >-
           ${{ runner.os }}-${{ steps.python.outputs.python-version
-          }}-${{ env.CACHE_KEY_PREFIX }}-${{ hashFiles('setup.cfg', 'test-requirements.txt', 'tox.ini') }}
+          }}-${{ env.CACHE_KEY_PREFIX }}-${{
+          hashFiles('deployment/resc-helm-wizard/setup.cfg', 'deployment/resc-helm-wizard/test-requirements.txt', 'deployment/resc-helm-wizard/tox.ini') }}
 
     - name: Install tox
       run: pip install -U pip setuptools tox

--- a/deployment/resc-helm-wizard/requirements.txt
+++ b/deployment/resc-helm-wizard/requirements.txt
@@ -1,3 +1,0 @@
-questionary==1.10.0
-requests==2.31.0
-PyYAML==6.0

--- a/deployment/resc-helm-wizard/setup.cfg
+++ b/deployment/resc-helm-wizard/setup.cfg
@@ -11,6 +11,10 @@ long_description_content_type = text/markdown
 
 [options]
 python_requires = >=3.9
+install_requires =
+    questionary
+    requests
+    PyYAML
 include_package_data = True
 zip_safe = False
 package_dir = = src

--- a/deployment/resc-helm-wizard/setup.py
+++ b/deployment/resc-helm-wizard/setup.py
@@ -1,12 +1,4 @@
-# Third Party
 from setuptools import setup
 
 
-def get_required_packages():
-    with open('requirements.txt') as f:
-        return f.read().splitlines()
-
-
-setup(
- install_requires=get_required_packages()
-)
+setup()

--- a/deployment/resc-helm-wizard/tests/test_common.py
+++ b/deployment/resc-helm-wizard/tests/test_common.py
@@ -24,7 +24,6 @@ from resc_helm_wizard.common import (
 from resc_helm_wizard.helm_value import HelmValue
 from resc_helm_wizard.vcs_instance import VcsInstance
 
-
 THIS_DIR = Path(__file__).parent
 
 

--- a/deployment/resc-helm-wizard/tests/test_common.py
+++ b/deployment/resc-helm-wizard/tests/test_common.py
@@ -24,7 +24,6 @@ from resc_helm_wizard.common import (
 from resc_helm_wizard.helm_value import HelmValue
 from resc_helm_wizard.vcs_instance import VcsInstance
 
-sys.path.insert(0, "src")
 
 THIS_DIR = Path(__file__).parent
 

--- a/deployment/resc-helm-wizard/tests/test_helm_utilities.py
+++ b/deployment/resc-helm-wizard/tests/test_helm_utilities.py
@@ -15,8 +15,6 @@ from resc_helm_wizard.helm_utilities import (
     validate_helm_deployment_status
 )
 
-sys.path.insert(0, "src")
-
 
 @patch("subprocess.check_output")
 @patch("logging.Logger.info")

--- a/deployment/resc-helm-wizard/tests/test_kubernetes_utilities.py
+++ b/deployment/resc-helm-wizard/tests/test_kubernetes_utilities.py
@@ -6,8 +6,6 @@ from unittest.mock import patch
 # First Party
 from resc_helm_wizard.kubernetes_utilities import create_namespace_if_not_exists
 
-sys.path.insert(0, "src")
-
 
 @patch("subprocess.run")
 @patch("subprocess.run")

--- a/deployment/resc-helm-wizard/tests/test_run_wizard.py
+++ b/deployment/resc-helm-wizard/tests/test_run_wizard.py
@@ -5,8 +5,6 @@ from unittest.mock import patch
 # First Party
 from resc_helm_wizard.run_wizard import prompt_questions
 
-sys.path.insert(0, "src")
-
 
 @patch("resc_helm_wizard.questions.ask_operating_system")
 @patch("resc_helm_wizard.common.create_storage_for_db_and_rabbitmq")

--- a/deployment/resc-helm-wizard/tests/test_validator.py
+++ b/deployment/resc-helm-wizard/tests/test_validator.py
@@ -12,8 +12,6 @@ from resc_helm_wizard.validator import (
     vcs_url_validator
 )
 
-sys.path.insert(0, "src")
-
 
 def test_password_validator():
     error_message = "Password must contain at least one upper case, one lower case, " \

--- a/deployment/resc-helm-wizard/tox.ini
+++ b/deployment/resc-helm-wizard/tox.ini
@@ -1,25 +1,32 @@
+[tox]
+minversion = 4.0.0
+skip_missing_interpreters = true
+envlist = py39, py310, py311
 
-[testenv:lint]
+[testenv]
+description = Run `pytest tests/` with {basepython}
+deps = -rtest-requirements.txt
+passenv = PIP_CONFIG_FILE
+commands =
+    pytest -v --cov=resc_helm_wizard --cov-config=.coveragerc tests
+
+[testenv:flake8]
+description = Run `flake8 src/`
 skipsdist = true
 skip_install = true
-passenv = PIP_CONFIG_FILE
-commands = pip install -r test-requirements.txt
-           pip install  -e .
-           flake8 src/ tests/
-           pylint src/
+commands =
+    flake8 src/
 
-[testenv:sort]
+[testenv:pylint]
+description = Run `pylint src/`
+skipsdist = true
+commands =
+    pylint src/
+
+[testenv:isort]
+description = Run `isort src/ tests/`
 skipsdist = true
 skip_install = true
-passenv = PIP_CONFIG_FILE
-commands = pip install isort==5.5.1
-           isort src/ tests/ --diff -m 3
-           isort src/ tests/ --check-only -m 3
-
-[testenv:pytest]
-skipsdist = true
-skip_install = true
-passenv = PIP_CONFIG_FILE
-commands = pip install -r test-requirements.txt
-           pip install  -e .
-           pytest -v  --cov=src --cov-config=.coveragerc  tests
+commands =
+    isort src/ tests/ --diff -m 3
+    isort src/ tests/ --check-only -m 3


### PR DESCRIPTION
**CI changes helm-wizard**
  - Run the test suite on each supported Python version (3.9, 3.10, 3.11).
  - Run the linting checks on Python 3.11.
  - (Performance) Add caching of the `.tox` directory to re-use the environment, downloaded/installed dependencies etc. When a change has been made to `setup.cfg`, `tox.ini` or `test-requirements.txt` the cache will be invalidated and new tox environments are created.


**Other changes**
  tox.ini:
    - Add the `tox` section with a `minversion` for tox
    - Add a list of Python environments so the tests will run in each one that is available on the machine. 
    - Move installation of requirements to `deps`. 
    - Don't install the package in development mode - instead install and test the package in the state in which it would be distributed. 
    - Separate flake8/pylint to different environments for easier debugging.

  **Remove `requirements.txt` and move its content inside `setup.py`**
    - Building an sdist via `tox` or `python build` produced an error related to missing `requirements.txt`. We could add `requirements.txt` to the `MANIFEST.in` but placing them in `setup.py` feels more natural for a package dependencies (and not a one-time environment/deployment requirements). 
    - loosen the dependency version requirements to avoid conflicts in a user's environment.

  **Remove the `sys.path.insert(0, "src")` from the test modules**
    - Can run the tests using `tox`. Alternatively run `pytest` directly and point the PYTHONPATH to the package directory.

  **Remove the `src/__init__.py` module**
  - The package is `resc_helm_wizard`.

