### PR TITLE
Update tox.ini and fix install requirements

### DIFF
--- a/components/resc-backend/tox.ini
+++ b/components/resc-backend/tox.ini
@@ -3,10 +3,11 @@
 skipsdist = true
 skip_install = true
 passenv = PIP_CONFIG_FILE
-commands = pip install -r test-requirements.txt
-           pip install  -e .
+commands = pip install  -e .
            flake8 src/ tests/
            pylint src/
+allowlist_externals = flake8
+                      pylint
 
 [testenv:sort]
 skipsdist = true
@@ -20,11 +21,11 @@ commands = pip install isort==5.5.1
 skipsdist = true
 skip_install = true
 passenv = PIP_CONFIG_FILE
-commands = pip install -r test-requirements.txt
-           pip install -e .
+commands = pip install -e .
            coverage run -m pytest
            coverage report -m
            coverage xml --data-file=.coverage          
+allowlist_externals = coverage
 
 [coverage:run]
 relative_files = True

--- a/components/resc-vcs-scanner/README.md
+++ b/components/resc-vcs-scanner/README.md
@@ -200,7 +200,7 @@ Run below commands to make sure that the unit tests are running and that the cod
 
 _**Note:**_ To run these tests you need to install [tox](https://pypi.org/project/tox/). This can be done on Linux and Windows with Git Bash.
 ```bash
-pip install tox      # install tox locally
+pip install -r test-requirements.txt      # install tox locally
 
 tox -v -e sort       # Run this command to validate the import sorting
 tox -v -e lint       # Run this command to lint the code according to this repository's standard

--- a/components/resc-vcs-scanner/tox.ini
+++ b/components/resc-vcs-scanner/tox.ini
@@ -3,11 +3,12 @@
 skipsdist = true
 skip_install = true
 passenv = PIP_CONFIG_FILE
-commands = pip install -r test-requirements.txt
-           pip install -e ../resc-backend
+commands = pip install -e ../resc-backend
            pip install  -e .
            flake8 src/ tests/
            pylint src/
+allowlist_externals = flake8
+                      pylint
 
 [testenv:sort]
 skipsdist = true
@@ -21,12 +22,12 @@ commands = pip install isort==5.5.1
 skipsdist = true
 skip_install = true
 passenv = PIP_CONFIG_FILE
-commands = pip install -r test-requirements.txt
-           pip install -e ../resc-backend
+commands = pip install -e ../resc-backend
            pip install -e .
            coverage run -m pytest
            coverage report -m
            coverage xml --data-file=.coverage         
+allowlist_externals = coverage
 
 [coverage:run]
 relative_files = True

--- a/components/resc-vcs-scraper/tox.ini
+++ b/components/resc-vcs-scraper/tox.ini
@@ -4,10 +4,11 @@ skipsdist = true
 skip_install = true
 passenv = PIP_CONFIG_FILE
 setenv = PYTHONPATH = {toxinidir}:{toxinidir}/src
-commands = pip install -r test-requirements.txt --quiet
-           pip install  -e .
+commands = pip install  -e .
            flake8 src/ tests/
            pylint src/
+allowlist_externals = flake8
+                      pylint
 
 [testenv:sort]
 skipsdist = true
@@ -22,11 +23,11 @@ skipsdist = true
 skip_install = true
 setenv = PYTHONPATH = {toxinidir}:{toxinidir}/src
 passenv = PIP_CONFIG_FILE
-commands = pip install -r test-requirements.txt --quiet
-           pip install -e .
+commands = pip install -e .
            coverage run -m pytest
            coverage report -m
            coverage xml --data-file=.coverage     
+allowlist_externals = coverage
 
 [coverage:run]
 relative_files = True

--- a/deployment/resc-helm-wizard/tox.ini
+++ b/deployment/resc-helm-wizard/tox.ini
@@ -16,12 +16,14 @@ skipsdist = true
 skip_install = true
 commands =
     flake8 src/
+allowlist_externals = flake8
 
 [testenv:pylint]
 description = Run `pylint src/`
 skipsdist = true
 commands =
     pylint src/
+allowlist_externals = pylint
 
 [testenv:isort]
 description = Run `isort src/ tests/`


### PR DESCRIPTION
Installing tox is done directly via `pip install -r test-requirements.txt`.
This ensures that a newer version of tox does not conflict with dependencies.