### PR TITLE
Add support for ignore rules

### DIFF
--- a/components/resc-vcs-scanner/README.md
+++ b/components/resc-vcs-scanner/README.md
@@ -163,7 +163,7 @@ To create vcs_instances_config.json file please refer to: [Structure of vcs_inst
   cd components/resc-vcs-scanner
   pip install virtualenv
   virtualenv venv
-  source venv/Scripts/activate
+  source venv/bin/activate
   ```
  #### 2. Install resc_vcs_scanner package:
   ```bash
@@ -174,25 +174,56 @@ The CLI has 3 modes of operation, please make use of the --help argument to see 
 - Scanning a non-git directory: 
   ```bash
   secret_scanner dir --help
-  secret_scanner dir --gitleaks-rules-path=<path to gitleaks toml rule> --gitleaks-path=<path to gitleaks binary> --dir=<directory to scan>
+  secret_scanner dir --gitleaks-rules-path=<path to gitleaks toml rule> --gitleaks-path=<path to gitleaks binary> --ignored-blocker-path=<path to resc-ignore.dsv file> --dir=<directory to scan>
   ```
 
 - Scanning an already cloned git repository: 
   ```bash
   secret_scanner repo local --help
-  secret_scanner repo local --gitleaks-rules-path=<path to gitleaks toml rule> --gitleaks-path=<path to gitleaks binary> --dir=<directory of repository to scan>
+  secret_scanner repo local --gitleaks-rules-path=<path to gitleaks toml rule> --gitleaks-path=<path to gitleaks binary> --ignored-blocker-path=<path to resc-ignore.dsv file> --dir=<directory of repository to scan>
   ```
 
 - Scanning a remote git repository: 
   ```bash
   secret_scanner repo remote --help
-  secret_scanner repo remote --gitleaks-rules-path=<path to gitleaks toml rule> --gitleaks-path=<path to gitleaks binary> --repo-url=<url of repository to scan>
+  secret_scanner repo remote --gitleaks-rules-path=<path to gitleaks toml rule> --gitleaks-path=<path to gitleaks binary> --ignored-blocker-path=<path to resc-ignore.dsv file> --repo-url=<url of repository to scan>
   ```
 Most CLI arguments can also be provided by setting the corresponding environment variable. 
 Please see the --help options on the arguments that can be provided using environment variables, and the expected environment variable names.
 These will always be prefixed with RESC_
 
 Example: the argument **--gitleaks-path** can be provided using the environment variable **RESC_GITLEAKS_PATH**
+</details>
+
+### Ignoring findings
+
+<details>
+  <summary>Preview</summary>
+
+It is possible to ignore some blocker findings (e.g. false positive) by providing
+a `resc-ignore.dsv` file. The bockers will be downgraded to a warning level and marked as **ignored**. Such file has the following structure:
+
+```sh
+# This is a comment
+finding_path|finding_rule|finding_line_number|expiration_date
+finding_path_2|finding_rule_2|finding_line_number_2
+```
+
+- `finding_path` contains the path to the file with the blocking finding.
+- `finding_rule` contains the name of the blocking rule.
+- `finding_line_number` contains the line number of the finding.
+- `expiration_date` is optional, contains the date in ISO 8601 format until which this ignore rule should be considered valid.
+
+For example, if we want to ignore the finding in file `/etc/passwd` for rule `root_value_found` on line `1` until April 1st 2024 at 23:59 the following line should be used.
+```sh
+/etc/passwd|root_value_found|1|2024-04-01T23:59:00
+```
+To ignore this finding _ad vitam aeternam_:
+```sh
+/etc/passwd|root_value_found|1
+```
+
+
 </details>
 
 ## Testing 

--- a/components/resc-vcs-scanner/src/vcs_scanner/helpers/finding_action.py
+++ b/components/resc-vcs-scanner/src/vcs_scanner/helpers/finding_action.py
@@ -5,4 +5,5 @@ from enum import Enum
 class FindingAction(str, Enum):
     INFO = "Info"
     WARN = "Warn"
+    IGNORED = "Ignored"
     BLOCK = "Block"

--- a/components/resc-vcs-scanner/src/vcs_scanner/secret_scanners/cli.py
+++ b/components/resc-vcs-scanner/src/vcs_scanner/secret_scanners/cli.py
@@ -47,6 +47,11 @@ def create_cli_argparser() -> ArgumentParser:
                                envvar="RESC_GITLEAKS_RULES_PATH", help="Path to the gitleaks rules file. "
                                                                        "Can also be set via the "
                                                                        "RESC_GITLEAKS_RULES_PATH environment variable")
+    parser_common.add_argument("--ignored-blocker-path", type=pathlib.Path, action=EnvDefault, required=False,
+                               envvar="RESC_IGNORED_BLOCKER_PATH", help="Path to the resc-ignore.dsv file. "
+                                                                        "Can also be set via the "
+                                                                        "RESC_IGNORED_BLOCKER_PATH "
+                                                                        "environment variable")
     parser_common.add_argument("-w", "--exit-code-warn", required=False, action=EnvDefault, default=2, type=int,
                                envvar="RESC_EXIT_CODE_WARN",
                                help="Exit code given if CLI encounters findings tagged with Warn, default 2. "
@@ -199,8 +204,10 @@ def scan_directory(args: Namespace):
     )
 
     output_plugin = STDOUTWriter(toml_rule_file_path=args.gitleaks_rules_path,
-                                 exit_code_warn=args.exit_code_warn, exit_code_block=args.exit_code_block,
-                                 filter_tag=args.filter_tag)
+                                 exit_code_warn=args.exit_code_warn,
+                                 exit_code_block=args.exit_code_block,
+                                 filter_tag=args.filter_tag,
+                                 ignore_findings_path=args.ignored_blocker_path)
     with open(args.gitleaks_rules_path, encoding="utf-8") as rule_pack:
         rule_pack_version = get_rule_pack_version_from_file(rule_pack.read())
     if not rule_pack_version:
@@ -244,8 +251,10 @@ def scan_repository(args: Namespace):
 
     else:
         output_plugin = STDOUTWriter(toml_rule_file_path=args.gitleaks_rules_path,
-                                     exit_code_warn=args.exit_code_warn, exit_code_block=args.exit_code_block,
-                                     filter_tag=args.filter_tag)
+                                     exit_code_warn=args.exit_code_warn,
+                                     exit_code_block=args.exit_code_block,
+                                     filter_tag=args.filter_tag,
+                                     ignore_findings_path=args.ignored_blocker_path)
         with open(args.gitleaks_rules_path, encoding="utf-8") as rule_pack:
             rule_pack_version = get_rule_pack_version_from_file(rule_pack.read())
     if not rule_pack_version:

--- a/components/resc-vcs-scanner/src/vcs_scanner/secret_scanners/ignore_list_provider.py
+++ b/components/resc-vcs-scanner/src/vcs_scanner/secret_scanners/ignore_list_provider.py
@@ -27,7 +27,7 @@ class IgnoredListProvider():  # pylint: disable=R0902
                 csv_ignore_list = csv.reader(ignore_findings_file, delimiter='|')
                 for row in csv_ignore_list:
                     expire: datetime = datetime.now()
- 
+
                     # rows starting with # are comments
                     if row[0][:1] == '#':
                         continue

--- a/components/resc-vcs-scanner/src/vcs_scanner/secret_scanners/ignore_list_provider.py
+++ b/components/resc-vcs-scanner/src/vcs_scanner/secret_scanners/ignore_list_provider.py
@@ -35,8 +35,8 @@ class IgnoredListProvider():  # pylint: disable=R0902
                         continue
 
                     if len(row) < 3:
-                        stringRow: str = "".join(row)
-                        logger.warning(f"Skipping: incomplete entry for {stringRow}")
+                        string_row: str = "".join(row)
+                        logger.warning(f"Skipping: incomplete entry for {string_row}")
                         continue
 
                     if len(row) > 3:

--- a/components/resc-vcs-scanner/src/vcs_scanner/secret_scanners/ignore_list_provider.py
+++ b/components/resc-vcs-scanner/src/vcs_scanner/secret_scanners/ignore_list_provider.py
@@ -1,0 +1,57 @@
+# pylint: disable=E1101
+# Standard Library
+import logging
+from datetime import datetime
+import dateutil.parser
+import csv
+
+logger = logging.getLogger(__name__)
+
+
+class IgnoredListProvider():  # pylint: disable=R0902
+
+    def __init__(self, ignore_findings_path: str):
+        self.ignore_findings_path: str = ignore_findings_path
+        self.today: datetime = datetime.now()
+
+    def get_ignore_list(self) -> dict:
+        """
+            Get the dictionary of ignored findings according to the file
+            The output will contain a dictionary with the findings id as the key and the tags as a list in the value
+        """
+        ignored = {}
+
+        try:
+            # read dsv: `path|rule_name|line_number|expiry_date`
+            with open(self.ignore_findings_path, encoding="utf-8") as ignore_findings_file:
+                csv_ignore_list = csv.reader(ignore_findings_file, delimiter='|')
+                for row in csv_ignore_list:
+                    expire: datetime = datetime.now()
+ 
+                    # rows starting with # are comments
+                    if row[0][:1] == '#':
+                        continue
+
+                    if len(row) < 3:
+                        stringRow: str = "".join(row)
+                        logger.warning(f"Skipping: incomplete entry for {stringRow}")
+                        continue
+
+                    if len(row) > 3:
+                        date = row[3]
+                        try:
+                            expire: datetime = dateutil.parser.isoparse(date)
+                        except ValueError:
+                            logger.warning(f"Skipping: invalid date entry for {date}")
+                            continue
+
+                    if expire < self.today:
+                        continue
+
+                    # we use the path, rule_name, line_number as a dictionary key
+                    ignored[row[0] + '|' + row[1] + '|' + row[2]] = True
+        except FileNotFoundError:  # <- File does not exists: we just fail silently
+            logger.warning(f"could not find {self.ignore_findings_path}")
+            return {}
+
+        return ignored

--- a/components/resc-vcs-scanner/src/vcs_scanner/secret_scanners/ignore_list_provider.py
+++ b/components/resc-vcs-scanner/src/vcs_scanner/secret_scanners/ignore_list_provider.py
@@ -1,9 +1,11 @@
 # pylint: disable=E1101
 # Standard Library
+import csv
 import logging
 from datetime import datetime
+
+# Third Party
 import dateutil.parser
-import csv
 
 logger = logging.getLogger(__name__)
 

--- a/components/resc-vcs-scanner/tests/fixtures/ignore-findings-list-for-writer.dsv
+++ b/components/resc-vcs-scanner/tests/fixtures/ignore-findings-list-for-writer.dsv
@@ -1,0 +1,1 @@
+file_path_1|rule_1|1

--- a/components/resc-vcs-scanner/tests/fixtures/ignore-findings-list.dsv
+++ b/components/resc-vcs-scanner/tests/fixtures/ignore-findings-list.dsv
@@ -1,0 +1,6 @@
+#commented_path|commented_rule|commented_line_number|expiry_date
+empty_line
+expired_path|expired_rule|38|2022-09-09T15:30:30
+wrong_date_path|wrong_date_rule|38|2022X09-09T15:30:30
+active_path|active_rule|57|2122-09-09T15:30:30
+active_path_2|active_rule_2|58

--- a/components/resc-vcs-scanner/tests/fixtures/rules.toml
+++ b/components/resc-vcs-scanner/tests/fixtures/rules.toml
@@ -1,0 +1,21 @@
+title = "gitleaks config"
+
+version = "2.0.13"
+
+[[rules]]
+	id = "rule_1"
+	description = "Fake rule"
+	regex = '''something'''
+	tags = ["Block"]
+
+[[rules]]
+	id = "rule_2"
+	description = "Another Fake rule"
+	regex = '''something'''
+	tags = ["Block"]
+
+[[rules]]
+	id = "rule_3"
+	description = "Another Fake rule again"
+	regex = '''something'''
+	tags = ["Warn"]

--- a/components/resc-vcs-scanner/tests/vcs_scanner/secret_scanners/test_ignore_list_provider.py
+++ b/components/resc-vcs-scanner/tests/vcs_scanner/secret_scanners/test_ignore_list_provider.py
@@ -1,0 +1,14 @@
+# Standard Library
+from pathlib import Path
+
+# First Party
+from vcs_scanner.secret_scanners.ignore_list_provider import IgnoredListProvider
+
+
+THIS_DIR = Path(__file__).parent.parent
+
+# We check that given a file, we get only 1 line:
+def test_ignore_list_provider():
+    ignore_list_path = THIS_DIR.parent / "fixtures/ignore-findings-list.dsv"
+    listProvider = IgnoredListProvider(str(ignore_list_path))
+    assert {'active_path|active_rule|57': True, 'active_path_2|active_rule_2|58': True} == listProvider.get_ignore_list()

--- a/components/resc-vcs-scanner/tests/vcs_scanner/secret_scanners/test_ignore_list_provider.py
+++ b/components/resc-vcs-scanner/tests/vcs_scanner/secret_scanners/test_ignore_list_provider.py
@@ -4,11 +4,12 @@ from pathlib import Path
 # First Party
 from vcs_scanner.secret_scanners.ignore_list_provider import IgnoredListProvider
 
-
 THIS_DIR = Path(__file__).parent.parent
+
 
 # We check that given a file, we get only 1 line:
 def test_ignore_list_provider():
     ignore_list_path = THIS_DIR.parent / "fixtures/ignore-findings-list.dsv"
     listProvider = IgnoredListProvider(str(ignore_list_path))
-    assert {'active_path|active_rule|57': True, 'active_path_2|active_rule_2|58': True} == listProvider.get_ignore_list()
+    assert {'active_path|active_rule|57': True,
+            'active_path_2|active_rule_2|58': True} == listProvider.get_ignore_list()

--- a/components/resc-vcs-scanner/tests/vcs_scanner/secret_scanners/test_stdout_writer.py
+++ b/components/resc-vcs-scanner/tests/vcs_scanner/secret_scanners/test_stdout_writer.py
@@ -1,6 +1,7 @@
 # Standard Library
 from datetime import datetime
 from unittest.mock import call, patch
+from pathlib import Path
 
 # Third Party
 from resc_backend.resc_web_service.schema.finding import Finding, FindingCreate
@@ -10,6 +11,8 @@ from resc_backend.resc_web_service.schema.scan import ScanRead
 
 # First Party
 from vcs_scanner.secret_scanners.stdout_writer import STDOUTWriter
+
+THIS_DIR = Path(__file__).parent.parent
 
 
 # A test method to check the happy flow of the write_repository method.
@@ -49,7 +52,9 @@ def test_write_findings(info_log, exit_mock, _get_rule_tags):
                                 event_sent_on=datetime.utcnow(),
                                 rule_name=f"rule_{i}"))
 
-    _ = STDOUTWriter(toml_rule_file_path="toml_path", exit_code_warn=2, exit_code_block=1) \
+    _ = STDOUTWriter(toml_rule_file_path="toml_path",
+                     exit_code_warn=2,
+                     exit_code_block=1) \
         .write_findings(1, 1, findings)
     calls = [call('\n'
                   '+-------+--------+------+----------+-------------+\n'
@@ -66,6 +71,88 @@ def test_write_findings(info_log, exit_mock, _get_rule_tags):
     info_log.assert_has_calls(calls, any_order=True)
     exit_mock.assert_called_with(0)
 
+
+@patch("sys.exit")
+@patch("logging.Logger.info")
+def test_write_findings_with_rules(info_log, exit_mock):
+    findings = []
+    toml_rule_path = THIS_DIR.parent / "fixtures/rules.toml"
+    for i in range(1, 6):
+        findings.append(Finding(file_path=f"file_path_{i}",
+                                line_number=i,
+                                column_start=i,
+                                column_end=i,
+                                commit_id=f"commit_id_{i}",
+                                commit_message=f"commit_message_{i}",
+                                commit_timestamp=datetime.utcnow(),
+                                author=f"author_{i}",
+                                email=f"email_{i}",
+                                status=FindingStatus.NOT_ANALYZED,
+                                comment=f"comment_{i}",
+                                event_sent_on=datetime.utcnow(),
+                                rule_name=f"rule_{i}"))
+
+    _ = STDOUTWriter(toml_rule_file_path=str(toml_rule_path),
+                     exit_code_warn=2,
+                     exit_code_block=1) \
+        .write_findings(1, 1, findings)
+    calls = [call('\n'
+                  '+-------+--------+------+----------+-------------+\n'
+                  '| Level | Rule   | Line | Position | File path   |\n'
+                  '+-------+--------+------+----------+-------------+\n'
+                  '| Block | rule_1 |    1 | 1-1      | file_path_1 |\n'
+                  '| Block | rule_2 |    2 | 2-2      | file_path_2 |\n'
+                  '| Info  | rule_4 |    4 | 4-4      | file_path_4 |\n'
+                  '| Info  | rule_5 |    5 | 5-5      | file_path_5 |\n'
+                  '| Warn  | rule_3 |    3 | 3-3      | file_path_3 |\n'
+                  '+-------+--------+------+----------+-------------+'),
+             call("Findings detected : Total - 5, Block - 2, Warn - 1, Info - 2"),
+             call("Scan failed due to policy violations: [Block:2]"),
+             call("Findings threshold check results: FAIL")]
+    info_log.assert_has_calls(calls, any_order=True)
+    exit_mock.assert_called_with(1)
+
+@patch("sys.exit")
+@patch("logging.Logger.info")
+def test_write_findings_with_rules_and_ignore(info_log, exit_mock):
+    findings = []
+    toml_rule_path = THIS_DIR.parent / "fixtures/rules.toml"
+    ignore_list_path = THIS_DIR.parent / "fixtures/ignore-findings-list-for-writer.dsv"
+    for i in range(1, 6):
+        findings.append(Finding(file_path=f"file_path_{i}",
+                                line_number=i,
+                                column_start=i,
+                                column_end=i,
+                                commit_id=f"commit_id_{i}",
+                                commit_message=f"commit_message_{i}",
+                                commit_timestamp=datetime.utcnow(),
+                                author=f"author_{i}",
+                                email=f"email_{i}",
+                                status=FindingStatus.NOT_ANALYZED,
+                                comment=f"comment_{i}",
+                                event_sent_on=datetime.utcnow(),
+                                rule_name=f"rule_{i}"))
+
+    _ = STDOUTWriter(toml_rule_file_path=str(toml_rule_path),
+                     exit_code_warn=2,
+                     exit_code_block=1,
+                     ignore_findings_path=ignore_list_path) \
+        .write_findings(1, 1, findings)
+    calls = [call('\n'
+                  '+---------+--------+------+----------+-------------+\n'
+                  '| Level   | Rule   | Line | Position | File path   |\n'
+                  '+---------+--------+------+----------+-------------+\n'
+                  '| Block   | rule_2 |    2 | 2-2      | file_path_2 |\n'
+                  '| Ignored | rule_1 |    1 | 1-1      | file_path_1 |\n'
+                  '| Info    | rule_4 |    4 | 4-4      | file_path_4 |\n'
+                  '| Info    | rule_5 |    5 | 5-5      | file_path_5 |\n'
+                  '| Warn    | rule_3 |    3 | 3-3      | file_path_3 |\n'
+                  '+---------+--------+------+----------+-------------+'),
+             call("Findings detected : Total - 5, Block - 1, Warn - 2, Info - 2"),
+             call("Scan failed due to policy violations: [Block:1]"),
+             call("Findings threshold check results: FAIL")]
+    info_log.assert_has_calls(calls, any_order=True)
+    exit_mock.assert_called_with(1)
 
 @patch("logging.Logger.info")
 def test_write_scan(info_log):

--- a/components/resc-vcs-scanner/tests/vcs_scanner/secret_scanners/test_stdout_writer.py
+++ b/components/resc-vcs-scanner/tests/vcs_scanner/secret_scanners/test_stdout_writer.py
@@ -112,6 +112,7 @@ def test_write_findings_with_rules(info_log, exit_mock):
     info_log.assert_has_calls(calls, any_order=True)
     exit_mock.assert_called_with(1)
 
+
 @patch("sys.exit")
 @patch("logging.Logger.info")
 def test_write_findings_with_rules_and_ignore(info_log, exit_mock):
@@ -153,6 +154,7 @@ def test_write_findings_with_rules_and_ignore(info_log, exit_mock):
              call("Findings threshold check results: FAIL")]
     info_log.assert_has_calls(calls, any_order=True)
     exit_mock.assert_called_with(1)
+
 
 @patch("logging.Logger.info")
 def test_write_scan(info_log):

--- a/components/resc-vcs-scanner/tests/vcs_scanner/secret_scanners/test_stdout_writer.py
+++ b/components/resc-vcs-scanner/tests/vcs_scanner/secret_scanners/test_stdout_writer.py
@@ -1,7 +1,7 @@
 # Standard Library
 from datetime import datetime
-from unittest.mock import call, patch
 from pathlib import Path
+from unittest.mock import call, patch
 
 # Third Party
 from resc_backend.resc_web_service.schema.finding import Finding, FindingCreate


### PR DESCRIPTION
### Ignoring findings

It is possible to ignore some blocker findings (e.g. false positive) by providing
a `resc-ignore.dsv` file. The bockers will be downgraded to a warning level and marked as **ignored**. Such file has the following structure:

```sh
# This is a comment
finding_path|finding_rule|finding_line_number|expiration_date
finding_path_2|finding_rule_2|finding_line_number_2
```

- `finding_path` contains the path to the file with the blocking finding.
- `finding_rule` contains the name of the blocking rule.
- `finding_line_number` contains the line number of the finding.
- `expiration_date` is optional, contains the date in ISO 8601 format until which this ignore rule should be considered valid.

For example, if we want to ignore the finding in file `/etc/passwd` for rule `root_value_found` on line `1` until April 1st 2024 at 23:59 the following line should be used.
```sh
/etc/passwd|root_value_found|1|2024-04-01T23:59:00
```
To ignore this finding _ad vitam aeternam_:
```sh
/etc/passwd|root_value_found|1
```
