### PR TITLE
Use `build` to build the `sdist` and `wheel` files.

### DIFF
--- a/.github/workflows/helm-wizard-ci.yaml
+++ b/.github/workflows/helm-wizard-ci.yaml
@@ -127,8 +127,8 @@ jobs:
       - name: Building python package
         run: |
           python -m pip install --upgrade pip
-          pip install build wheel
-          python setup.py sdist bdist_wheel
+          pip install build
+          python -m build
 
       - name: Publish python package to PyPI
         if: ${{ needs.python-basic-validation.outputs.branch_name == 'main' }}

--- a/.github/workflows/helm-wizard-ci.yaml
+++ b/.github/workflows/helm-wizard-ci.yaml
@@ -126,8 +126,7 @@ jobs:
 
       - name: Building python package
         run: |
-          python -m pip install --upgrade pip
-          pip install build
+          python -m pip install --upgrade pip build
           python -m build
 
       - name: Publish python package to PyPI


### PR DESCRIPTION
- [build](https://pypa-build.readthedocs.io/en/latest/#python--m-build) is currently installed but unused in the CI.
- Running `python -m build` first creates a `sdist` and then creates a wheel from that sdist, ensuring the sdist works.
  The current command gives no guarantee that the sdist would be usable when doing a `pip install sdist` - This is the case with the other backend packages in the codebase currently; for example, try downloading the published [resc-backend source distribution](https://pypi.org/project/resc-backend/#files) and doing a `pip install <sdist>`.

- Remove install of `wheel` since we are using `build`.

