### PR TITLE
Add pvc csi option

### DIFF
--- a/deployment/kubernetes/README.md
+++ b/deployment/kubernetes/README.md
@@ -67,19 +67,19 @@ Create two folders in your user folder and name them _database_ and _rabbitmq_ a
 Windows: C:\Users\<username>\resc\database and C:\Users\<username>\resc\rabbitmq  
 Linux: /Users/<username>/var/resc/database and /Users/<username>/var/resc/rabbitmq
 
-Update persistent volume claim path and hostOS for database.
+Update persistent volume claim path and filemountType for database.
 ```
 Windows:
 --------------
 resc-database:
-  hostOS: "windows"
+  filemountType: "windows"
   database:
     pvc_path: "/run/desktop/mnt/host/c/Users/<username>/resc/database"
 
 Linux:
 --------------
 resc-database:
-  hostOS: "linux"
+  filemountType: "linux"
   database:
     pvc_path: "/Users/<username>/var/resc/database"
 ```

--- a/deployment/kubernetes/charts/resc-database/templates/database_persistent_volume.yaml
+++ b/deployment/kubernetes/charts/resc-database/templates/database_persistent_volume.yaml
@@ -11,7 +11,7 @@ metadata:
     type: local
   {{ end }}
 spec:
-  {{ if ne .Values.filemountType "windows" }}
+  {{ if and (ne .Values.filemountType "windows") (ne .Values.hostOS "windows") }}
   storageClassName: {{ .Values.global.appName }}-sql-storage
   {{ end }}
   capacity:
@@ -22,7 +22,7 @@ spec:
   {{ if eq .Values.filemountType "csi" }}
   csi:
     {{- toYaml .Values.csi | nindent 4 }}
-  {{ else if eq .Values.filemountType "windows" }}
+  {{ else if or (eq .Values.filemountType "windows") (eq .Values.hostOS "windows") }}
   local:
     path: {{ .Values.database.pvc_path }}
   nodeAffinity:

--- a/deployment/kubernetes/charts/resc-database/templates/database_persistent_volume.yaml
+++ b/deployment/kubernetes/charts/resc-database/templates/database_persistent_volume.yaml
@@ -6,14 +6,14 @@ metadata:
   namespace: {{ .Values.global.namespace }}
   annotations:
     pv.beta.kubernetes.io/gid: "999"
-  {{- if ne .Values.filemountType "csi" }}
+  {{ if ne .Values.filemountType "csi" }}
   labels:
     type: local
-  {{- end }}
+  {{ end }}
 spec:
-  {{- if ne .Values.filemountType "windows" }}
+  {{ if ne .Values.filemountType "windows" }}
   storageClassName: {{ .Values.global.appName }}-sql-storage
-  {{- end }}
+  {{ end }}
   capacity:
     storage: {{ .Values.database.pvc_size }}
   accessModes:
@@ -21,9 +21,7 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   {{ if eq .Values.filemountType "csi" }}
   csi:
-    {{- range $key, $val := .Values.csi }}
-    {{ $key }}: {{ $val | quote }}
-    {{- end }}
+    {{- toYaml .Values.csi | nindent 4 }}
   {{ else if eq .Values.filemountType "windows" }}
   local:
     path: {{ .Values.database.pvc_path }}

--- a/deployment/kubernetes/charts/resc-database/templates/database_persistent_volume.yaml
+++ b/deployment/kubernetes/charts/resc-database/templates/database_persistent_volume.yaml
@@ -6,18 +6,25 @@ metadata:
   namespace: {{ .Values.global.namespace }}
   annotations:
     pv.beta.kubernetes.io/gid: "999"
+  {{- if ne .Values.filemountType "csi" }}
   labels:
     type: local
+  {{- end }}
 spec:
-  {{ if ne .Values.hostOS "windows" }}
+  {{- if ne .Values.filemountType "windows" }}
   storageClassName: {{ .Values.global.appName }}-sql-storage
-  {{ end }}
+  {{- end }}
   capacity:
     storage: {{ .Values.database.pvc_size }}
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
-  {{ if eq .Values.hostOS "windows" }}
+  {{ if eq .Values.filemountType "csi" }}
+  csi:
+    {{- range $key, $val := .Values.csi }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{ else if eq .Values.filemountType "windows" }}
   local:
     path: {{ .Values.database.pvc_path }}
   nodeAffinity:

--- a/deployment/kubernetes/charts/resc-database/templates/database_persistent_volume_claim.yaml
+++ b/deployment/kubernetes/charts/resc-database/templates/database_persistent_volume_claim.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.global.appName }}-database-pv-volume-claim
   namespace: {{ .Values.global.namespace }}
 spec:
-  {{ if ne .Values.hostOS "windows" }}
+  {{ if ne .Values.filemountType "windows" }}
   storageClassName: {{ .Values.global.appName }}-sql-storage
   {{ end }}
   accessModes:

--- a/deployment/kubernetes/charts/resc-database/templates/database_persistent_volume_claim.yaml
+++ b/deployment/kubernetes/charts/resc-database/templates/database_persistent_volume_claim.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.global.appName }}-database-pv-volume-claim
   namespace: {{ .Values.global.namespace }}
 spec:
-  {{ if ne .Values.filemountType "windows" }}
+  {{ if and (ne .Values.filemountType "windows") (ne .Values.hostOS "windows") }}
   storageClassName: {{ .Values.global.appName }}-sql-storage
   {{ end }}
   accessModes:

--- a/deployment/kubernetes/charts/resc-database/values.yaml
+++ b/deployment/kubernetes/charts/resc-database/values.yaml
@@ -1,4 +1,5 @@
-hostOS: ""
+filemountType: ""
+csi:
 database:
   exposeToHostPort:
   port: 1433

--- a/deployment/kubernetes/charts/resc-rabbitmq/templates/rabbitmq_persistent_volume.yaml
+++ b/deployment/kubernetes/charts/resc-rabbitmq/templates/rabbitmq_persistent_volume.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: {{ .Values.global.namespace }}
   annotations:
     pv.beta.kubernetes.io/gid: "999"
-  {{- if ne .Values.filemountType "csi" }}
+  {{ if ne .Values.filemountType "csi" }}
   labels:
     type: local
-  {{- end }}
+  {{ end }}
 spec:
   {{ if ne .Values.filemountType "windows" }}
   storageClassName: {{ .Values.global.appName }}-mq-storage
@@ -26,9 +26,7 @@ spec:
     readOnly: false
   {{ else if eq .Values.filemountType "csi" }}
   csi:
-    {{- range $key, $val := .Values.csi }}
-    {{ $key }}: {{ $val | quote }}
-    {{- end }}
+    {{ toYaml .Values.csi | nindent 4 }}
   {{ else if eq .Values.filemountType "windows" }}
   local:
     path: {{ .Values.rabbitMQ.pvc_path }}
@@ -44,4 +42,3 @@ spec:
   hostPath:
     path: {{ .Values.rabbitMQ.pvc_path }}
   {{ end }}
-  

--- a/deployment/kubernetes/charts/resc-rabbitmq/templates/rabbitmq_persistent_volume.yaml
+++ b/deployment/kubernetes/charts/resc-rabbitmq/templates/rabbitmq_persistent_volume.yaml
@@ -5,8 +5,10 @@ metadata:
   namespace: {{ .Values.global.namespace }}
   annotations:
     pv.beta.kubernetes.io/gid: "999"
+  {{- if ne .Values.filemountType "csi" }}
   labels:
     type: local
+  {{- end }}
 spec:
   {{ if ne .Values.filemountType "windows" }}
   storageClassName: {{ .Values.global.appName }}-mq-storage
@@ -22,8 +24,12 @@ spec:
     secretNamespace: resc
     shareName: resc-data
     readOnly: false
-  {{ else }}
-  {{ if eq .Values.filemountType "windows" }}
+  {{ else if eq .Values.filemountType "csi" }}
+  csi:
+    {{- range $key, $val := .Values.csi }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{ else if eq .Values.filemountType "windows" }}
   local:
     path: {{ .Values.rabbitMQ.pvc_path }}
   nodeAffinity:
@@ -38,4 +44,4 @@ spec:
   hostPath:
     path: {{ .Values.rabbitMQ.pvc_path }}
   {{ end }}
-  {{ end }}
+  

--- a/deployment/kubernetes/example-values.yaml
+++ b/deployment/kubernetes/example-values.yaml
@@ -89,7 +89,7 @@ resc-web-service-no-auth:
       redisPass: "Y0urStr0ngPassword" # <enter Redis password here for caching, default to Y0urStr0ngPassword>
 
 resc-database:
-  hostOS: "windows" # possible values windows/linux
+  filemontType: "windows" # possible values csi/windows/linux
   database:
     exposeToHostPort: 30880
     pvc_path: "/run/desktop/mnt/host/c/Users/<username>/resc/database" # "<enter path to store database data>" # Linux: /Users/<username>/var/resc/database, Windows: # /run/desktop/mnt/host/c/Users/<username>/resc/database
@@ -114,7 +114,7 @@ resc-rabbitmq:
       queues_username: "queue_user" # <enter queue username, default to queue_user>
       queues_password: "Y0urStr0ngPassword" # <enter queue password, default to Y0urStr0ngPassword>
     pvc_path: "/run/desktop/mnt/host/c/Users/<username>/resc/rabbitmq" # "<enter path to store rabbitmq data>" # Linux: /Users/<username>/var/resc/rabbitmq, Windows: # /run/desktop/mnt/host/c/Users/<username>/resc/rabbitmq
-  filemountType: "windows" # possible values windows/linux/azure
+  filemountType: "windows" # possible values windows/linux/azure/csi
 
 resc-redis:
   redis:

--- a/deployment/resc-helm-wizard/src/resc_helm_wizard/common.py
+++ b/deployment/resc-helm-wizard/src/resc_helm_wizard/common.py
@@ -211,7 +211,7 @@ def create_helm_values_yaml(
     try:
         values_dict = read_yaml_file(input_values_yaml_file)
 
-        values_dict["resc-database"]["hostOS"] = helm_values.operating_system
+        values_dict["resc-database"]["filemountType"] = helm_values.operating_system
         values_dict["resc-database"]["database"]["pvc_path"] = (
             helm_values.db_storage_path
         )

--- a/deployment/resc-helm-wizard/src/resc_helm_wizard/config/example-values.yaml
+++ b/deployment/resc-helm-wizard/src/resc_helm_wizard/config/example-values.yaml
@@ -89,7 +89,7 @@ resc-web-service-no-auth:
       redisPass: "Y0urStr0ngPassword" # <enter Redis password here for caching, default to Y0urStr0ngPassword>
 
 resc-database:
-  hostOS: "windows" # possible values windows/linux
+  filemountType: "windows" # possible values windows/linux/csi
   database:
     exposeToHostPort: 30880
     pvc_path: "/run/desktop/mnt/host/c/Users/<username>/resc/database" # "<enter path to store database data>" # Linux: /Users/<username>/var/resc/database, Windows: # /run/desktop/mnt/host/c/Users/<username>/resc/database
@@ -114,7 +114,7 @@ resc-rabbitmq:
       queues_username: "queue_user" # <enter queue username, default to queue_user>
       queues_password: "Y0urStr0ngPassword" # <enter queue password, default to Y0urStr0ngPassword>
     pvc_path: "/run/desktop/mnt/host/c/Users/<username>/resc/rabbitmq" # "<enter path to store rabbitmq data>" # Linux: /Users/<username>/var/resc/rabbitmq, Windows: # /run/desktop/mnt/host/c/Users/<username>/resc/rabbitmq
-  filemountType: "windows" # possible values windows/linux/azure
+  filemountType: "windows" # possible values windows/linux/azure/csi
 
 resc-redis:
   redis:

--- a/deployment/resc-helm-wizard/tests/resc_helm_wizard/fixtures/test-values.yaml
+++ b/deployment/resc-helm-wizard/tests/resc_helm_wizard/fixtures/test-values.yaml
@@ -1,5 +1,5 @@
 resc-database:
-  hostOS: ""
+  filemountType: ""
   database:
     pvc_path: ""
     config:


### PR DESCRIPTION
Implements abnamro/repository-scanner#235

Add option to use CSI as backend for persistent volume. I have replaced the "hostOS" value with "filemountType" to align with the configuration of the RabbitMQ deployment and it checks for both keys for backward-compatibility reasons.

